### PR TITLE
Override executable bit on the Discord executable.

### DIFF
--- a/template.spec
+++ b/template.spec
@@ -53,6 +53,7 @@ ln -s %{_datadir}/%{lowercase_name}/%{name} $RPM_BUILD_ROOT/%{_bindir}
 
 %files
 %{_bindir}/%{name}
+%attr(0755, root, root) %{_datadir}/%{lowercase_name}/%{name}
 %{_datadir}/%{lowercase_name}
 %{_datadir}/applications/*.desktop
 %{_datadir}/pixmaps/*.png


### PR DESCRIPTION
The archives that Discord distribute are missing the executable bit on the `/usr/share/discord/Discord` executable. So the symlinks at `/usr/bin/Discord/` and `/usr/bin/DiscordCanary` don't work, and the `.desktop` files disappear from Application menus. The correct solution is for Discord to distribute archives with the correct executable bit, but we can also mitigate this issue in the RPMBuild spec here for anyone that's using the installer COPR.

Signed-off-by: William Temple <William.Temple@colorado.edu>